### PR TITLE
API-217905 WorkPlan.read method doesn't work when workplanId parameter is used

### DIFF
--- a/onevizion.py
+++ b/onevizion.py
@@ -892,7 +892,7 @@ class WorkPlan(object):
 				)
 		else:
 			#1234
-			FilterSection = str(trackorId)
+			FilterSection = str(workplanId)
 
 		URL = "https://{URL}/api/v3/wps/{FilterSection}".format(URL=self.URL, FilterSection=FilterSection)
 		self.errors = []


### PR DESCRIPTION
[API-217905](https://trackor.onevizion.com/form/ConfigAppForm.do?id=100106806276&ttid=10009161) WorkPlan.read method doesn't work when workplanId parameter is used

Bug fixed: in the read method of the WorkPlan class, when the value of the workplanId parameter is passed, trackorId is used instead of workplanId
