### PR TITLE
API-175773 Use log level 'Error' by default

### DIFF
--- a/onevizion.py
+++ b/onevizion.py
@@ -1832,7 +1832,7 @@ class IntegrationLog(object):
 	Exception can be thrown for method 'add'
 	"""
 
-	def __init__(self, processId, URL="", userName="", password="", paramToken=None, isTokenAuth=False, logLevelName=""):
+	def __init__(self, processId, URL="", userName="", password="", paramToken=None, isTokenAuth=False, logLevelName="Error"):
 		self._URL = URL
 		self._userName = userName
 		self._password = password


### PR DESCRIPTION
[API-175773](https://trackor.onevizion.com/form/ConfigAppForm.do?id=100100707881&ttid=10009161) Use log level 'Error' by default
Fixed a bug in which, if the logLevelName parameter was missing in the initialization of the IntegrationLog class, an exception appeared. Now by default logLevelName is "Error"
